### PR TITLE
Expose `Request` type and sync tests up with master branch of `miso`

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,7 +29,7 @@ myComponent :: MyComponent
 myComponent = component () update_ view_
   where
 #if MIN_VERSION_miso(1,13,0)
-      view_ :: () -> () -> () -> View () () Action
+      view_ :: () -> () -> () -> View () Action
       view_ _ _ _ =
 #elif MIN_VERSION_miso(1,11,0)
       view_ :: () -> () -> View () Action

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE CPP               #-}
 -----------------------------------------------------------------------------
 module Main where
 -----------------------------------------------------------------------------
@@ -25,10 +26,22 @@ main = startApp defaultEvents myComponent
 type MyComponent = App () Action
 -----------------------------------------------------------------------------
 myComponent :: MyComponent
-myComponent = component () update_ $ \() ->
-  H.div_ []
-  [ button_ [ onClick Download ] [ "download" ]
-  ] where
+myComponent = component () update_ view_
+  where
+#if MIN_VERSION_miso(1,13,0)
+      view_ :: () -> () -> () -> View () () Action
+      view_ _ _ _ =
+#elif MIN_VERSION_miso(1,11,0)
+      view_ :: () -> () -> View () Action
+      view_ _ _ =
+#else
+      view_  :: () -> View () Action
+      view_ _ =
+#endif
+        H.div_ []
+        [ button_ [ onClick Download ] [ "download" ]
+        ]
+      
       update_ = \case
         Download -> do
           io_ (consoleLog "clicked")
@@ -75,7 +88,13 @@ uploadFile :<|> downloadFile = toClient mempty (Proxy @API)
 -----------------------------------------------------------------------------
 type GitHubAPI = Get '[JSON] Value
 -----------------------------------------------------------------------------
+#if MIN_VERSION_miso(1,13,0)
+downloadGithub :: (Response Value -> Action) -> (Response MisoString -> Action) -> Effect () props () Action
+#elif MIN_VERSION_miso(1,11,0)
+downloadGithub :: (Response Value -> Action) -> (Response MisoString -> Action) -> Effect ROOT () () Action
+#else
 downloadGithub :: (Response Value -> Action) -> (Response MisoString -> Action) -> Effect ROOT () Action
+#endif
 downloadGithub successsful errorful = withSink $ \sink ->
   toClient "https://api.github.com" (Proxy @GitHubAPI) (sink . successsful) (sink . errorful)
 -----------------------------------------------------------------------------

--- a/servant-miso-client.cabal
+++ b/servant-miso-client.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               servant-miso-client
-version:            0.2.0.0
+version:            0.2.1.0
 synopsis:           miso integration with servant-client
 description:        Client integration between servant and miso using the Fetch API
 homepage:           https://github.com/haskell-miso/servant-miso-client

--- a/src/Servant/Miso/Client.hs
+++ b/src/Servant/Miso/Client.hs
@@ -15,6 +15,7 @@ module Servant.Miso.Client
   , MimeRender (..)
   , MimeUnrender (..)
   , toClient
+  , Request (..)
   ) where
 -----------------------------------------------------------------------------
 import           Miso.JSON


### PR DESCRIPTION
This PR does the following:

1. Exposes `Request(..)`
2. Ensures the tests can compile against `miso` master.

`Request(..)` I have exposed because instances in [`servant-miso-multipart-client`](https://github.com/grcsolutions-au/servant-multipart-miso-client/blob/master/src/Servant/Multipart/Miso/Client.hs) need to access `_reqBody`. 

Actually, the second point doesn't exactly work, because the way it is achieved is with a CPP gate for miso version `0.13.0.0`. I presume this will be the next release number of Miso, but for now bumping `miso` `master` itself to `0.13.0.0` will allow the tests to compile.

Miso master is still version `0.12.0.0`, but I believe it has an incompatible interface with the actual `0.12.0.0` release. 

I used CPP in the tests because the package itself has no issues compiling against `0.11`, `0.12` and `master`, so I didn't think it was necessary to version restrict the miso dependency version itself just because of some test code.
